### PR TITLE
Trainline logo is not publicly exposed

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2271,6 +2271,8 @@
 			cursor: default;
 			display: inline-block;
 			margin: 0 0 1.5em 0;
+			height: 44px;
+			width: 204px;
 		}
 
 			.icon.major:before {

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 		<!-- Header -->
 			<section id="header">
 				<div class="inner">
-					<span class="icon major"><img src="https://st1-static-trainlinecontent.ttlnonprod.com/content/ETL/1.19.3/trainline-logo-green@2x.png" alt="" /></span>
+					<span class="icon major"><img src="http://ehelp.thetrainline.com/euf/assets/themes/ecommerce_2015/tango_2015/logo-trainline.svg" alt="" /></span>
 					<h1>Trainline Engineering Summit 2017</h1>
 					<p>Wednesday, 21st June 2017 - 9am - 6:30pm</br>
 					   <a href="https://twitter.com/search?f=tweets&q=%23TrainlineTech17%20%23Engineering" class="icon alt fa-twitter"><span class="label">#TrainlineTech17 #Engineering</span></a><a href="https://twitter.com/search?f=tweets&q=%23TrainlineTech17%20%23Engineering"><span class="label">#TrainlineTech17 #Engineering</span></a></br>


### PR DESCRIPTION
Current logo comes from staging asset folder which is not publicly accessible.
Replaced with the one I found on http://ehelp.thetrainline.com
**Disclaimer**: Not sure this is the best logo :-)