### PR TITLE
fix firefox link bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,12 @@
 			<h2>#lessPainMoreTrain🚂</h2>
 			<div class="intro">
 				<p>Friday, 6th July 2018</p>
-				<button type="button">
-					<a href="https://goo.gl/forms/p70Y8jPfZQMyGnLX2">Submit a talk</a>
-				</button>
+				<p>
+					<a href="https://goo.gl/forms/p70Y8jPfZQMyGnLX2" class="btn" target="_blank">
+						Submit a talk
+					</a>
+				</p>
+
 				<p class="place">
 					<!-- <address>Kings Place,
 						<br>90 York Way,

--- a/main.css
+++ b/main.css
@@ -69,17 +69,20 @@ address {
   color: #fff;
   font-size: 24px;
   text-decoration: none;
+  margin: 15px;
 }
 
-.intro button:hover {
+.intro .btn:hover {
   background-color: #017564;
 }
-.intro button {
+.intro .btn {
+  text-align: center;
+  width: 200px;
   color: #ffffff;
   background-color: #01c3a7;
   border: none;
   padding: 20px;
-  margin: 5px;
+  margin: 15px;
   border-radius: 8px;
   font-family: trainline, Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
can't have `a` in `button` in firefox 